### PR TITLE
Fix URL extraction regex

### DIFF
--- a/packages/shared/src/utils/urls.ts
+++ b/packages/shared/src/utils/urls.ts
@@ -14,9 +14,15 @@ export function extractUrls(text: string): string[] {
   });
 
   // Then look for any remaining plain URLs in the text
-  const plainUrlRegex = /https?:\/\/[^\s<\]]+(?:[^<.,:;"'\]\s)]|(?=\s|$))/g;
+  // Match any remaining plain URLs. We'll trim trailing punctuation
+  // since URLs followed by punctuation (e.g. "," or ")") should not
+  // include those characters.
+  const plainUrlRegex = /https?:\/\/\S+/g;
   const plainUrls = processedText.match(plainUrlRegex) || [];
-  plainUrls.forEach((url) => urls.add(url));
+  plainUrls.forEach((url) => {
+    const cleaned = url.replace(/[.,:;"'\)\]]+$/u, "");
+    urls.add(cleaned);
+  });
 
   return Array.from(urls);
 }


### PR DESCRIPTION
## Summary
- fix URL extraction to strip trailing punctuation

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`